### PR TITLE
Remove VirtualSmc.efi from Drivers list

### DIFF
--- a/EFI-OpenCore/EFI/OC/config.plist
+++ b/EFI-OpenCore/EFI/OC/config.plist
@@ -1309,7 +1309,6 @@
 			<string>HfsPlus.efi</string>
 			<string>ApfsDriverLoader.efi</string>
 			<string>FwRuntimeServices.efi</string>
-			<string>VirtualSmc.efi</string>
 		</array>
 		<key>Input</key>
 		<dict>


### PR DESCRIPTION
Since ee482f5b86df59f81d556585d7912b6c190def81 we haven't needed to use 
`VirtualSmc.efi` however it's still included in the Drivers list.

This removes the listing so that it boots properly out of the box.